### PR TITLE
Sped up encode62 and decode62

### DIFF
--- a/lib/radix62.rb
+++ b/lib/radix62.rb
@@ -7,6 +7,13 @@ module Radix62
   ALPHABET = ('0'..'9').to_a + ('a'..'z').to_a + ('A'..'Z').to_a
   ALPHABET_HASH = {}
   ALPHABET.each_with_index { |v,k| ALPHABET_HASH[v] = k }
+
+  KeyError = begin
+    KeyError
+  rescue NameError
+    IndexError
+  end
+  
   
   # Encode an Integer to a base 62 string. The input value *must* be a positive 
   # integer.

--- a/lib/radix62.rb
+++ b/lib/radix62.rb
@@ -5,6 +5,8 @@ require "radix62/core_ext/integer"
 # Convert integers to base 62 strings and back.
 module Radix62
   ALPHABET = ('0'..'9').to_a + ('a'..'z').to_a + ('A'..'Z').to_a
+  ALPHABET_HASH = {}
+  ALPHABET.each_with_index { |v,k| ALPHABET_HASH[v] = k }
   
   # Encode an Integer to a base 62 string. The input value *must* be a positive 
   # integer.
@@ -15,36 +17,34 @@ module Radix62
     unless number.is_a? Integer
       raise TypeError.new "number not an integer"
     end
-    
-    if number < 0
-      raise RangeError.new "number must be greater than or equal to 0"
+  
+    if number > 0
+      base62 = ""
+      while number > 0
+        base62 << ALPHABET[number % 62]
+        number /= 62
+      end
+      base62.reverse
     elsif number == 0
-      return "0"
+      "0"
+    else
+      raise RangeError.new "number must be greater than or equal to 0"
     end
-
-    base62 = ""
-      
-    while number > 0
-      base62 << ALPHABET[number.modulo(62)]
-      number /= 62
-    end
-    
-    base62.reverse
   end
+
   
   # Decode a base 62 String to a base 10 Integer. The input value 
   # <b>must not</b> contain illegal characters.
   # 
   # If the input is not alphanumeric, an ArgumentError will be raised.
   def self.decode62(string)
-    if !!string.match(/^([a-z0-9]+)$/i)
+    begin
       integer = 0
-      string.split(//).reverse.each_with_index do |char,index|
-        place = ALPHABET.size ** index
-        integer += ALPHABET.find_index(char) * place
+      string.split(//).each do |char|
+        integer = integer * 62 + ALPHABET_HASH.fetch(char)
       end
       integer
-    else
+    rescue KeyError
       raise ArgumentError.new "Input is not alphanumeric."
     end
   end

--- a/spec/radix62_spec.rb
+++ b/spec/radix62_spec.rb
@@ -18,6 +18,21 @@ describe Radix62 do
     end
   end
   
+  context "alphabet_hash" do
+    it "has the ALPHABET_HASH hash" do
+      Radix62::ALPHABET_HASH.should be_kind_of Hash
+    end
+    
+    it "has 62 items" do
+      Radix62::ALPHABET_HASH.should_not be_empty
+      Radix62::ALPHABET_HASH.count.should == 62
+    end
+    
+    it "has the right contents" do
+      Radix62::ALPHABET_HASH.should == {"0"=>0, "1"=>1, "2"=>2, "3"=>3, "4"=>4, "5"=>5, "6"=>6, "7"=>7, "8"=>8, "9"=>9, "a"=>10, "b"=>11, "c"=>12, "d"=>13, "e"=>14, "f"=>15, "g"=>16, "h"=>17, "i"=>18, "j"=>19, "k"=>20, "l"=>21, "m"=>22, "n"=>23, "o"=>24, "p"=>25, "q"=>26, "r"=>27, "s"=>28, "t"=>29, "u"=>30, "v"=>31, "w"=>32, "x"=>33, "y"=>34, "z"=>35, "A"=>36, "B"=>37, "C"=>38, "D"=>39, "E"=>40, "F"=>41, "G"=>42, "H"=>43, "I"=>44, "J"=>45, "K"=>46, "L"=>47, "M"=>48, "N"=>49, "O"=>50, "P"=>51, "Q"=>52, "R"=>53, "S"=>54, "T"=>55, "U"=>56, "V"=>57, "W"=>58, "X"=>59, "Y"=>60, "Z"=>61}
+    end
+  end
+  
   context "encode62" do
     it "raises an exception with negative numbers" do
       (-1000..-1).step(100).each do |n|


### PR DESCRIPTION
I have refactored the code to speed up the encode62 and decode62 methods. My benchmarks show encode62 is 20% faster and decode62 is 100% faster. Their functionality stays the same so all the tests still pass. I have also added a few tests where relevant. I will explain the changes:
### Encode62
- Changed the order of the if statement so that the most common choice comes fast and the least common last. This means less time is spent performing comparisons in most cases.
- Switched `.modulo()` method to `%` modulo operator as this is faster. Not sure why, perhaps an extra method call.
### Decode62
- Added `ALPHABET_HASH` constant so that we can look up the number of each letter by key rather than using `.find_index()` which is slower.
- Changed the algorithm so that we aren't calculating a power within the loop, we can use `.each` rather than `.each_with_index` and removed the `.reverse` as the results come in the right order now already.
- Removed the Regex as this was slow. The same error checking is achieved by using `.find()` on the hash which raised an exception if the key is not found. We then catch that exception to return our own more descriptive exception from before.

This is a very minor pull request for a not huge speed increase, but I think it is still worth it, because a few milliseconds here and there could speed up a URL shortener. I love the gem, it's nice and simple. Thanks!
